### PR TITLE
Add Bybit webhook signature verification

### DIFF
--- a/api/bybit_webhook.py
+++ b/api/bybit_webhook.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter, Request, HTTPException
+from services.bybit_signature import verify_signature
+
+router = APIRouter()
+
+@router.post('/bybit')
+async def bybit_webhook(request: Request):
+    payload = await request.body()
+    recv_timestamp = request.headers.get('X-BAPI-TIMESTAMP', '')
+    signature = request.headers.get('X-BAPI-SIGN', '')
+    if not verify_signature(payload, recv_timestamp, signature):
+        raise HTTPException(status_code=401, detail='Invalid signature')
+    return {'status': 'ok'}

--- a/config.py
+++ b/config.py
@@ -1,0 +1,1 @@
+BYBIT_WEBHOOK_SECRET = 'changeme'

--- a/services/bybit_signature.py
+++ b/services/bybit_signature.py
@@ -1,0 +1,10 @@
+import hmac
+import hashlib
+import config
+
+def verify_signature(payload: bytes, recv_timestamp: str, signature: str) -> bool:
+    message = recv_timestamp.encode() + payload
+    expected_signature = hmac.new(
+        config.BYBIT_WEBHOOK_SECRET.encode(), message, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected_signature, signature)

--- a/tests/test_bybit_signature.py
+++ b/tests/test_bybit_signature.py
@@ -1,0 +1,22 @@
+import hmac
+import hashlib
+import config
+from services.bybit_signature import verify_signature
+
+def test_verify_signature_valid():
+    config.BYBIT_WEBHOOK_SECRET = 'secret'
+    payload = b'{"key":"value"}'
+    recv_timestamp = '1587711043467'
+    expected_signature = hmac.new(
+        config.BYBIT_WEBHOOK_SECRET.encode(),
+        recv_timestamp.encode() + payload,
+        hashlib.sha256,
+    ).hexdigest()
+    assert verify_signature(payload, recv_timestamp, expected_signature)
+
+def test_verify_signature_invalid():
+    config.BYBIT_WEBHOOK_SECRET = 'secret'
+    payload = b'{"key":"value"}'
+    recv_timestamp = '1587711043467'
+    invalid_signature = 'invalid'
+    assert not verify_signature(payload, recv_timestamp, invalid_signature)


### PR DESCRIPTION
## Summary
- add HMAC-SHA256 verification module for Bybit webhooks
- verify signature in API endpoint and return 401 on failure
- cover verification logic with unit tests based on Bybit docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b3d42b648327975c688d4ea71501